### PR TITLE
Disable redir_party_num

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -230,7 +230,6 @@ persist.vendor.radio.manual_nw_rej_ct=1
 persist.vendor.radio.mbn_trace=true
 persist.vendor.radio.procedure_bytes=SKIP
 persist.vendor.radio.rat_on=combine
-persist.vendor.radio.redir_party_num=1
 persist.vendor.radio.sib16_support=1
 ro.telephony.call_ring.multiple=false
 ro.telephony.default_cdma_sub=0


### PR DESCRIPTION
Caused incoming caller number not being parsed correctly by Phone app on
VoLTE and VoWiFi.
Like this
https://github.com/InVictusXV/device_xiaomi_vayu/commit/054b7230c87c222db905666bc2733cc11fac9fcb