### PR TITLE
sm7350-common: Vibration hack for current broken haptic feedback effects

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -344,4 +344,24 @@
          flag is set for wifi displays.
     -->
     <bool name="config_wifiDisplaySupportsProtectedBuffers">false</bool>
+
+    <!-- Enables or disables haptic effect when the text insertion/selection handle is moved
+         manually by the user. Off by default, since the expected haptic feedback may not be
+         available on some devices. -->
+    <bool name="config_enableHapticTextHandle">true</bool>
+
+    <!-- The default intensity level for haptic feedback. See
+         Settings.System.HAPTIC_FEEDBACK_INTENSITY more details on the constant values and
+         meanings. -->
+    <integer name="config_defaultHapticFeedbackIntensity">3</integer>
+
+    <!-- The default intensity level for notification vibrations. See
+         Settings.System.NOTIFICATION_VIBRATION_INTENSITY more details on the constant values and
+         meanings. -->
+    <integer name="config_defaultNotificationVibrationIntensity">3</integer>
+
+    <!-- The default intensity level for notification vibrations. See
+         Settings.System.RING_VIBRATION_INTENSITY more details on the constant values and
+         meanings. -->
+    <integer name="config_defaultRingVibrationIntensity">3</integer>
 </resources>

--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -25,4 +25,8 @@
 
     <!-- Doze: does this device support STATE_DOZE_SUSPEND?  -->
     <bool name="doze_suspend_display_state_supported">false</bool>
+
+    <!-- Should we vibrate on an icon animation of the shelf. This should only be active if the
+    vibrator is capable of subtle vibrations -->
+    <bool name="config_vibrateOnIconAnimation">true</bool>
 </resources>

--- a/overlay/packages/apps/Settings/res/values/config.xml
+++ b/overlay/packages/apps/Settings/res/values/config.xml
@@ -15,10 +15,6 @@
 -->
 
 <resources>
-    <!-- Whether or not the device is capable of multiple levels of vibration intensity.
-         Note that this is different from whether it can control the vibration amplitude as some
-         devices will be able to vary their amplitude but do not possess enough dynamic range to
-         have distinct intensity levels -->
-    <bool name="config_vibration_supports_multiple_intensities">true</bool>
+
 
 </resources>

--- a/vibrator/aidl/Vibrator.cpp
+++ b/vibrator/aidl/Vibrator.cpp
@@ -307,11 +307,7 @@ int InputFFDevice::setAmplitude(uint8_t amplitude) {
 int InputFFDevice::playEffect(int effectId, EffectStrength es, long *playLengthMs) {
     switch (es) {
     case EffectStrength::LIGHT:
-        mCurrMagnitude = LIGHT_MAGNITUDE;
-        break;
     case EffectStrength::MEDIUM:
-        mCurrMagnitude = MEDIUM_MAGNITUDE;
-        break;
     case EffectStrength::STRONG:
         mCurrMagnitude = STRONG_MAGNITUDE;
         break;

--- a/vibrator/effect/effect.cpp
+++ b/vibrator/effect/effect.cpp
@@ -80,13 +80,16 @@ static struct effect_stream effects[] = {
 
 // Array containing the paths to fifo data in vendor.
 // The position in the array must match the effect id.
+// seq_bin_wav1.bin = STRONG
+// seq_bin_wav4.bin = SOFT
+// seq_bin_wav5.bin = MILD
 static const std::string fifo_data_paths[] = {
+    "/vendor/firmware/seq_bin_wav5.bin",
     "/vendor/firmware/seq_bin_wav1.bin",
-    "/vendor/firmware/seq_bin_wav2.bin",
-    "/vendor/firmware/seq_bin_wav3.bin",
+    "/vendor/firmware/seq_bin_wav4.bin",
     "/vendor/firmware/seq_bin_wav4.bin",
     "/vendor/firmware/seq_bin_wav5.bin",
-    "/vendor/firmware/seq_bin_wav6.bin",
+    "/vendor/firmware/seq_bin_wav5.bin",
 };
 
 // Function to parse custom fifo data from vendor


### PR DESCRIPTION
- [x] Fix: Haptic feedback effect triggering with `LIGHT_MAGNITUDE` after device initialization
- [x] Add: Haptic feedback when moving input cursor

Currently Pixel Experience ROM for Renoir doesn't support changing the haptic intensities in the Settings.
In some weird cases, system automatically changes the haptic strength to 0x3fff from 0x7fff after device do full initialization which doesn't give enough strength to give for a hand to feel. This commit will always trigger the haptics with 0x7fff (STRONG_MAGNITUDE) intensity.